### PR TITLE
1) SSL is optional with #define TWISTEDCPP_NEED_SSL. Disabled by defa…

### DIFF
--- a/include/twisted/detail/sockets.hpp
+++ b/include/twisted/detail/sockets.hpp
@@ -3,9 +3,12 @@
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#ifdef TWISTEDCPP_NEED_SSL
 #include <boost/asio/ssl.hpp>
+#endif
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/read.hpp>
+#include <boost/asio/write.hpp>
 
 namespace twisted {
 
@@ -72,9 +75,16 @@ public:
 
     virtual void close() { _socket.close(); }
 
+#if BOOST_VERSION >= 107000
+	virtual boost::asio::io_context& get_io_service() {
+		return ((boost::asio::io_context&)_socket.get_executor().context());
+	}
+
+#else
     virtual boost::asio::io_service& get_io_service() {
         return _socket.get_io_service();
     }
+#endif
 
     boost::asio::ip::tcp::socket& lowest_layer() { return _socket; }
 
@@ -84,6 +94,7 @@ private:
     boost::asio::ip::tcp::socket _socket;
 };
 
+#ifdef TWISTEDCPP_NEED_SSL
 class ssl_socket : public socket_base {
 public:
     ssl_socket(boost::asio::io_service& io_service,
@@ -143,6 +154,7 @@ public:
 private:
     boost::asio::ssl::stream<boost::asio::ip::tcp::socket> _socket;
 };
+#endif
 } // namespace detail
 
 } // namespace twisted

--- a/include/twisted/reactor.hpp
+++ b/include/twisted/reactor.hpp
@@ -2,7 +2,9 @@
 #define TWISTEDCPP_REACTOR_HPP
 
 #include "detail/sockets.hpp"
+#ifdef TWISTEDCPP_NEED_SSL
 #include "ssl_options.hpp"
+#endif
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -64,6 +66,7 @@ public:
      * href="http://www.boost.org/doc/libs/1_57_0/doc/html/boost_asio/reference/ssl__context.html">boost::asio
      * ssl context</a> - sets the ssl/tls options
      */
+#ifdef TWISTEDCPP_NEED_SSL
     template <typename ProtocolType, typename... Args>
     void listen_ssl(int port, ssl_options&& ssl_opts, Args&&... args) {
         std::shared_ptr<ssl_options> ssl_opts_ptr // move capture
@@ -74,6 +77,7 @@ public:
             ssl_impl<ProtocolType>(acceptor, yield, ssl_opts_ptr, std::forward<Args>(args)...);
         });
     }
+#endif
 
 private:
     template <typename ProtocolType, typename... Args>
@@ -87,6 +91,7 @@ private:
         run_loop<ProtocolType>(acceptor, yield, socket_factory, std::forward<Args>(args)...);
     }
 
+#ifdef TWISTEDCPP_NEED_SSL
     template <typename ProtocolType, typename... Args>
     void ssl_impl(boost::asio::ip::tcp::acceptor& acceptor,
                   boost::asio::yield_context yield,
@@ -98,6 +103,7 @@ private:
 
         run_loop<ProtocolType>(acceptor, yield, socket_factory, std::forward<Args>(args)...);
     }
+#endif
 
     template <typename ProtocolType, typename SocketFactory, typename... Args>
     void run_loop(boost::asio::ip::tcp::acceptor& acceptor,


### PR DESCRIPTION
…ult.

2) Fixed compile error for Boost > v1.70